### PR TITLE
Install the YARP dependency from PyPI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,11 +36,8 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo sh -c 'echo "deb http://www.icub.org/ubuntu $(lsb_release -cs) contrib/science" > \
-              /etc/apt/sources.list.d/icub.list'
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 57A5ACB6110576A6
-          sudo apt-get update
-          sudo apt-get install -y yarp pybind11-dev
+          sudo apt update
+          sudo apt install -y libace-dev
 
       - name: Install sdist
         run: pip -v install dist/*.tar.gz
@@ -86,21 +83,8 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_24
           CIBW_ENVIRONMENT_LINUX: AUDITWHEEL_PLAT=manylinux_2_24_x86_64
           CIBW_BEFORE_ALL_LINUX: |
-              echo "deb http://ftp.debian.org/debian stretch-backports main" | tee -a \
-                  /etc/apt/sources.list.d/stretch-backports.list &&\
-              echo "deb http://ftp.debian.org/debian stretch-backports-sloppy main" | tee -a \
-                  /etc/apt/sources.list.d/stretch-backports-sloppy.list &&\
-              apt-get update &&\
-              apt-get install -y --no-install-recommends \
-                  lsb-release lsb-core dirmngr &&\
-              apt-get install -y --no-install-recommends -t stretch-backports-sloppy libarchive13 &&\
-              apt-get install -y --no-install-recommends -t stretch-backports cmake &&\
-              echo "deb http://www.icub.org/debian buster contrib/science" | tee -a \
-                  /etc/apt/sources.list.d/icub.list &&\
-              apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 57A5ACB6110576A6 &&\
-              apt-get update &&\
-              apt-get install -y --no-install-recommends yarp &&\
-              ln -s /usr/lib/libACE.so /usr/lib/libACE-6.4.5.so
+            apt update &&\
+            apt install -y libace-dev
           CIBW_TEST_COMMAND: "python -c 'from gazebo_yarp_synchronizer import GazeboYarpSynchronizer'"
 
       - uses: actions/upload-artifact@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,15 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "cmake>=3.14", "ninja", "cmake-build-extension", "pybind11", "wheel"]
+requires = [
+    "setuptools>=42", 
+    "setuptools_scm[toml]>=3.4", 
+    "cmake>=3.14",
+    "ninja", 
+    "cmake-build-extension", 
+    "pybind11", 
+    "wheel",
+    "yarp-middleware",
+    "ycm-cmake-modules",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -41,13 +41,15 @@ setup(
         "ninja",
         "cmake-build-extension",
         "pybind11",
+        "yarp-middleware",
+        "ycm-cmake-modules",
     ],
     python_requires='>=3.7',
     install_requires=[],
     ext_modules=[
         CMakeExtension(name='InstallAllTargets',
                        install_prefix="gazebo_yarp_synchronizer",
-                       cmake_depends_on=["pybind11"],
+                       cmake_depends_on=["pybind11", "yarp", "ycm_cmake_modules"],
                        disable_editable=True,
                        cmake_configure_options=[
                            "-DBUILD_SHARED_LIBS:BOOL=OFF",


### PR DESCRIPTION
Now that `yarp-middleware` landed in PyPI (https://github.com/robotology/yarp/pull/2573), we can greatly simplify the dependencies of the CI/CD pipeline.

Fixes https://github.com/diegoferigo/gazebo-yarp-synchronizer/issues/1.